### PR TITLE
Speaker: Fix self assignment in constructor.

### DIFF
--- a/MonoBrickFirmware/Sound/Speaker.cs
+++ b/MonoBrickFirmware/Sound/Speaker.cs
@@ -44,7 +44,7 @@ namespace MonoBrickFirmware.Sound
 		
 		public Speaker (int volume)
 		{
-			currentVolume = Volume;
+			currentVolume = volume;
 		}
 		
 		public int Volume {


### PR DESCRIPTION
`volume` (parameter) was misspelled as `Volume` (property), resulting in an indirect self assignment.
