### PR TITLE
NXTColorSensor: Fix constructor ignoring mode.

### DIFF
--- a/MonoBrickFirmware/Sensors/NXTColorSensor.cs
+++ b/MonoBrickFirmware/Sensors/NXTColorSensor.cs
@@ -131,7 +131,7 @@ namespace MonoBrickFirmware.Sensors
 		public NXTColorSensor (SensorPort port, ColorMode mode) :  base(port)
 		{
 			GetColorData();
-			SetMode(AnalogMode);	
+			SetMode((AnalogMode)mode);	
 		}
 		
 		/// <summary>


### PR DESCRIPTION
The constructor set the mode from the `AnalogMode` property, effectively resulting in a self-assignment.

DISCLAIMER: Completely untested, sent from the GitHub Web editor.
