### PR TITLE
Update AOTHelper.cs

### DIFF
--- a/MonoBrickFirmware/Native/AOTHelper.cs
+++ b/MonoBrickFirmware/Native/AOTHelper.cs
@@ -13,7 +13,7 @@ namespace MonoBrickFirmware.Native
 		public static bool Compile(string fileName){
 	      if (IsFileCompiled(fileName))
 				File.Delete(new FileInfo(fileName).Name + ".so");
-	      ProcessHelper.RunAndWaitForProcessWithOutput("mono", "--aot=full " + fileName);
+	      ProcessHelper.RunAndWaitForProcessWithOutput("/usr/local/bin/mono", "--aot=full " + fileName);
 	      return IsFileCompiled(fileName);
 		}
 	}


### PR DESCRIPTION
Change the path of mono in Compile() method to absolute form, since relative path causes exception when invoking that method from StartupApp.exe via "Run In AOT" and "Compile AOT" menu.
