### PR TITLE
Add Template for F#

### DIFF
--- a/AddIn/MonoBrickAddin.csproj
+++ b/AddIn/MonoBrickAddin.csproj
@@ -4,7 +4,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{314570C2-D0F1-45D2-868D-FA54E2F538F8}</ProjectGuid>
-    <ProjectTypeGuids>{7DBEB09D-BB9F-4D92-A141-A009135475EF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <RootNamespace>MonoBrickAddin</RootNamespace>
     <AssemblyName>MonoBrickAddin</AssemblyName>
@@ -42,11 +41,21 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Mono.Cairo" />
-    <Reference Include="atk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
-    <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
-    <Reference Include="glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
-    <Reference Include="gdk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
-    <Reference Include="pango-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
+    <Reference Include="atk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
+      <Package>gtk-sharp-2.0</Package>
+    </Reference>
+    <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
+      <Package>gtk-sharp-2.0</Package>
+    </Reference>
+    <Reference Include="glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
+      <Package>glib-sharp-2.0</Package>
+    </Reference>
+    <Reference Include="gdk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
+      <Package>gtk-sharp-2.0</Package>
+    </Reference>
+    <Reference Include="pango-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
+      <Package>gtk-sharp-2.0</Package>
+    </Reference>
     <Reference Include="MonoDevelop.Core">
       <HintPath>External\MonoDevelop.Core.dll</HintPath>
     </Reference>
@@ -108,6 +117,10 @@
       <Link>MonoBrickFirmware.dll</Link>
       <LogicalName>MonoBrick.MonoBrickFirmware.dll</LogicalName>
       <DeployService-Deploy>True</DeployService-Deploy>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Templates\MonoBrickFSharpProject.xpt.xml">
+      <DeployService-Deploy>True</DeployService-Deploy>
+      <LogicalName>MonoBrickFSharpProject.xpt.xml</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/AddIn/Source/MonoBrickAddin.addin.xml
+++ b/AddIn/Source/MonoBrickAddin.addin.xml
@@ -7,7 +7,7 @@
 		copyright="MIT X11" 
 		description="MonoBrick solution and debugging" 
 		category="Mindstorms" 
-		version="0.1">
+		version="1.1.1">
 
 	<Dependencies>
 		<Addin id="::MonoDevelop.Core" version="5.0" />
@@ -34,6 +34,7 @@
 
 	<Extension path = "/MonoDevelop/Ide/ProjectTemplates">
 		<ProjectTemplate id = "MonoBrickProject" resource = "MonoBrickProject.xpt.xml"/>
+		<ProjectTemplate id = "MonoBrickFSharpProject" resource = "MonoBrickFSharpProject.xpt.xml"/>
 	</Extension>
 
 	<Extension path = "/MonoDevelop/ProjectModel/ProjectBindings">

--- a/AddIn/Templates/MonoBrickFSharpProject.xpt.xml
+++ b/AddIn/Templates/MonoBrickFSharpProject.xpt.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<Template originator   = "Bernhard Straub"
+          created      = "2013/12/31"
+          lastModified = "2014/12/29">
+	
+	<!-- Template Header -->
+	<TemplateConfiguration>
+		<_Name>MonoBrick F# Project</_Name>
+		<_Category>MonoBrick</_Category>
+		<Icon>md-project-gui</Icon>
+		<LanguageName>F#</LanguageName>
+		<_Description>MonoBrick F# Project</_Description>
+		<DefaultFilename>MonoBrickFSharpProject</DefaultFilename>
+	</TemplateConfiguration>
+	
+	<!-- Actions -->
+	<Actions>
+		<Open filename = "Program.fs"/>
+	</Actions>
+
+	<!-- Template Content -->
+	<Combine name = "${ProjectName}" directory = ".">
+		<Options>
+			<StartupProject>${ProjectName}</StartupProject>
+		</Options>
+		
+		<Project name = "${ProjectName}" directory = "." type = "MonoBrick">
+			<Options Target = "Exe" MainFile = "Program.fs" TargetFrameworkVersion="4.0"/>
+			<Options>
+				<UseMSBuildEngine>False</UseMSBuildEngine>
+			</Options>
+
+			<References>
+				<Reference type="Assembly" refto="MonoBrickFirmware.dll" />
+				<Reference type="Package" refto="mscorlib" />
+				<Reference type="Gac" refto="FSharp.Core" />
+				<Reference type="Package" refto="System" />
+				<Reference type="Package" refto="System.Core" />
+			</References>
+
+			<Files>
+				<File name="Program.fs">
+<![CDATA[open System
+open System.Threading
+open MonoBrickFirmware
+open MonoBrickFirmware.Display.Dialogs
+open MonoBrickFirmware.Display
+
+let main() =
+    Lcd.Instance.Clear()
+    LcdConsole.WriteLine("Hello World!")
+
+main()]]>
+				</File>
+			</Files>
+		</Project>
+	</Combine>
+</Template>


### PR DESCRIPTION
I have added a F# template to the Monodevelop Addin with a working "Hello World!" example. This way you can run the program on the EV3 the same way as you are able to using C#. Just FSharp.Core.dll has to be added to gac on the EV3...