### PR TITLE
Removed documented parameter that doesn't exist

### DIFF
--- a/MonoBrickFirmware/Sound/Speaker.cs
+++ b/MonoBrickFirmware/Sound/Speaker.cs
@@ -54,7 +54,6 @@ namespace MonoBrickFirmware.Sound
 		/// <summary>
 		/// Play a tone.
 		/// </summary>
-		/// <param name="volume">Volume.</param>
 		/// <param name="frequency">Frequency of the tone</param>
 		/// <param name="durationMs">Duration in ms.</param>
 		public void PlayTone(UInt16 frequency, UInt16 durationMs){


### PR DESCRIPTION
The method only has two parameters, but the documentation showed three.